### PR TITLE
Add menu command to update the URL of a bookmark to that of current tab.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -78,6 +78,17 @@
             }
         }
     },
+    "confirmUpdateBookmark": {
+        "message": "Are you sure you want to update bookmark $bookmarkName$ to $newURL$?",
+        "placeholders": {
+            "bookmarkName": {
+                "content": "$1"
+            },
+            "newURL": {
+                "content": "$2"
+            }
+        }
+    },
     "deleteEllipsis": {
         "message": "Delete..."
     },
@@ -104,6 +115,12 @@
     },
     "unsetHotkey": {
         "message": "Unset Hotkey"
+    },
+    "updateEllipsis": {
+        "message": "Update..."
+    },
+    "update": {
+        "message": "Update"
     },
     "errorOccured": {
         "message": "Oops, an error occurred."

--- a/neat.js
+++ b/neat.js
@@ -45,6 +45,7 @@ function init() {
         'bookmark-new-window': 'openNewWindow',
         'bookmark-new-incognito-window': 'openIncognitoWindow',
         'bookmark-edit': 'edit',
+        'bookmark-update': 'updateEllipsis',
         'bookmark-delete': 'deleteEllipsis',
         'bookmark-set-hotkey': 'setHotkeyEllipsis',
         'bookmark-unset-hotkey': 'unsetHotkey',
@@ -582,6 +583,33 @@ function init() {
             });
         },
 
+        updateBookmark: function(id) {
+            chrome.tabs.query({ active: true, lastFocusedWindow: true }, function (tabs) {
+                var new_url = tabs[0].url;
+                var li = $('neat-tree-item-' + id);
+                var bookmarkName = '<cite>' + li.textContent.trim() + '</cite>';
+                var dialog = _m('confirmUpdateBookmark', [bookmarkName, new_url]);
+                ConfirmDialog.open({
+                    dialog: dialog,
+                    button1: '<strong>' + _m('update') + '</strong>',
+                    button2: _m('nope'),
+                    fn1: function() {
+                        chrome.bookmarks.update(id, { url: new_url }, function(n) {
+                            var title = n.title;
+                            var url = n.url;
+                            var css = li.querySelector('a').style.cssText;
+                            li.innerHTML = generateBookmarkHTML(title, url, 'style="' + css + '"');
+                            li.firstElementChild.focus();
+                        });
+                    },
+                    fn2: function() {
+                        li.querySelector('a, span').focus();
+                    }
+                });
+
+            });
+        },
+
         deleteBookmark: function(id) {
             var li = $('neat-tree-item-' + id);
 
@@ -827,6 +855,11 @@ function init() {
                 var li = currentContext.parentNode;
                 var id = li.id.replace(/(neat\-tree)\-item\-/, '');
                 actions.editBookmarkFolder(id);
+                break;
+            case 'bookmark-update':
+                var li = currentContext.parentNode;
+                var id = li.id.replace(/(neat\-tree)\-item\-/, '');
+                actions.updateBookmark(id);
                 break;
             case 'bookmark-delete':
                 var li = currentContext.parentNode;

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,7 @@
     <command id="bookmark-new-incognito-window" tabindex="-1">
     <hr>
     <command id="bookmark-edit" tabindex="-1">
+    <command id="bookmark-update" tabindex="-1">
     <command id="bookmark-delete" tabindex="-1">
     <hr>
     <command id="bookmark-set-hotkey" tabindex="-1">


### PR DESCRIPTION
Some web sites have a large amount of content spread across multiple pages
which are read in order over several user sessions (e.g. like an online
book, web comic, or other periodical).

This feature allows the user to easily update one of their bookmarks as
they proceed through the content. For example creating the bookmark after
they had read chapter 4, return to site, read chapters 5-7 and "update"
the same bookmark to the start of chapter 8 so they could resume where they
left off at a later time.

Signed-off-by: David Holmer odinguru@gmail.com
